### PR TITLE
Update languag mismatch

### DIFF
--- a/resources/translations/Update by word.bru
+++ b/resources/translations/Update by word.bru
@@ -15,8 +15,8 @@ body:json {
     "word": "chien",
     "lang": "fr",
     "translations": [
-      "schnufi",
-      "fido"
+      "hund",
+      "köter"
     ],
     "translation_lang": "de"
   }

--- a/src/domain/update_translation.rs
+++ b/src/domain/update_translation.rs
@@ -46,7 +46,7 @@ pub async fn update_translation<T: Repository<TranslationRecord>>(
             .map(|t| t.to_string())
             .collect(),
         extra_translation_lang.clone(),
-    );
+    )?;
 
     let updated_tr = repository.update(&tr_to_be_updated).await?;
 

--- a/src/driven/repository/mongo_repository.rs
+++ b/src/driven/repository/mongo_repository.rs
@@ -313,8 +313,8 @@ mod tests {
         let mut tr = repo.create(&stub_translation_record(false)).await.unwrap();
         let extra_translations = ADDITONAL_TRANSLATIONS.map(|r| r.to_string()).to_vec();
         let mut expected_tr = tr.clone();
-        expected_tr.update(extra_translations.clone(), Lang::de);
-        tr.update(extra_translations, Lang::de);
+        let _ = expected_tr.update(extra_translations.clone(), Lang::de);
+        let _ = tr.update(extra_translations, Lang::de);
 
         let updated_tr = repo.update(&tr).await.unwrap();
 


### PR DESCRIPTION
When updating a translation record, with the wrong language, we not only want no update but also an error returned.